### PR TITLE
[ngfd-watch.spec] Align indentation, adhere to changelog format etc., …

### DIFF
--- a/rpm/ngfd-watch.spec
+++ b/rpm/ngfd-watch.spec
@@ -1,10 +1,10 @@
-Name:   ngfd-watch
-Version:  0.0.2
-Release:  1
-Summary:  Watchdog for ngfd
+Name:       ngfd-watch
+Version:    0.0.4
+Release:    1
+Summary:    Watchdog for ngfd
 BuildArch:  noarch
-License:  GPLv3+
-URL:    https://github.com/b100dian/ngfd-watch
+License:    GPLv3+
+URL:        https://github.com/b100dian/ngfd-watch
 Source0:    %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires: systemd
@@ -42,8 +42,8 @@ ln -s ../ngfd-watch.service %{buildroot}%{_userunitdir}/ngfd.service.wants/ngfd-
 
 %changelog
 * Tue Jan 10 2023 Vlad G. <vlad@grecescu.net> - 0.0.4-1
-  Display name in notification. Configure via /etc/ngfd-watch.
-* Mon Jan 9 2023 Vlad G. <vlad@grecescu.net> - 0.0.3-1
+- Display name in notification. Configure via /etc/ngfd-watch.
+* Mon Jan 09 2023 Vlad G. <vlad@grecescu.net> - 0.0.3-1
 - More sampling + kills by consecutive samples count
-* Sun Jan 8 2023 Vlad G. <vlad@grecescu.net> - 0.0.2-1
+* Sun Jan 08 2023 Vlad G. <vlad@grecescu.net> - 0.0.2-1
 - Initial detection by ogg file descriptor

--- a/rpm/ngfd-watch.spec
+++ b/rpm/ngfd-watch.spec
@@ -3,7 +3,7 @@ Version:    0.0.4
 Release:    1
 Summary:    Watchdog for ngfd
 BuildArch:  noarch
-License:    GPLv3+
+License:    GPL-3.0-or-later
 URL:        https://github.com/b100dian/ngfd-watch
 Source0:    %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 


### PR DESCRIPTION
… because you recommended this RPM spec file as exemplary: https://forum.sailfishos.org/t/ad-blocking-in-sailfishos-in-2023-what-are-the-options/15799/27?u=olf

NB: The RPM changelog format is documented here [1] and here [2]; this is an exemplary `changes` file with multi-level indention etc.: https://github.com/sailfishos-chum/sailfishos-chum-gui/blob/main/rpm/sailfishos-chum-gui.changes
* [1] https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/SF4VVE4NBEDQJDJZ4DJ6YW2DTGMWP23E/#6O6DFC6GDOLCU7QC3QJKJ3VCUGAOTD24
* [2] https://en.opensuse.org/openSUSE:Creating_a_changes_file_(RPM)

NB2: Please always use correct SPDX license identifiers, see https://spdx.org/licenses/
They are what automated license checks expect since more than 10 years ago.